### PR TITLE
POA: Credentry SSO — NumbatWallet-side hardening + deploy wiring (config-gated off)

### DIFF
--- a/.github/workflows/deploy-numbatwallet.yml
+++ b/.github/workflows/deploy-numbatwallet.yml
@@ -166,11 +166,35 @@ jobs:
           # tokens stop matching and logins break. Sourced from the repo secret
           # (mirrors KV kv-numbatwallet-test-aue/search-token-pepper).
           SEARCH_TOKEN_PEPPER: ${{ secrets.SEARCH_TOKEN_PEPPER }}
+          # Credentry SSO federation. Stays DISABLED (chart default) until Credentry
+          # provisions the nonprod clients — then set repo variable CREDENTRY_ENABLED=true
+          # plus CREDENTRY_AUTHORITY + the tenant-map GUIDs. The admin client secret rides
+          # the K8s secret (bootstrap-namespace.sh), not here.
+          CREDENTRY_ENABLED: ${{ vars.CREDENTRY_ENABLED }}
+          CREDENTRY_AUTHORITY: ${{ vars.CREDENTRY_AUTHORITY }}
+          CREDENTRY_TENANT_CREDENTRY_GUID: ${{ vars.CREDENTRY_TENANT_CREDENTRY_GUID }}
+          CREDENTRY_TENANT_NUMBAT_GUID: ${{ vars.CREDENTRY_TENANT_NUMBAT_GUID }}
         run: |
+          CREDENTRY_ARGS=()
+          if [ "${CREDENTRY_ENABLED}" = "true" ]; then
+            echo "Credentry SSO: ENABLED for this deploy"
+            CREDENTRY_ARGS+=(--set api.credentry.enabled=true --set admin.credentry.enabled=true)
+            if [ -n "${CREDENTRY_AUTHORITY}" ]; then
+              CREDENTRY_ARGS+=(--set "api.credentry.authority=${CREDENTRY_AUTHORITY}")
+              CREDENTRY_ARGS+=(--set "admin.credentry.authority=${CREDENTRY_AUTHORITY}")
+            fi
+            if [ -n "${CREDENTRY_TENANT_CREDENTRY_GUID}" ] && [ -n "${CREDENTRY_TENANT_NUMBAT_GUID}" ]; then
+              CREDENTRY_ARGS+=(--set "api.credentry.tenantMap.${CREDENTRY_TENANT_CREDENTRY_GUID}=${CREDENTRY_TENANT_NUMBAT_GUID}")
+              CREDENTRY_ARGS+=(--set "admin.credentry.tenantMap.${CREDENTRY_TENANT_CREDENTRY_GUID}=${CREDENTRY_TENANT_NUMBAT_GUID}")
+            fi
+          else
+            echo "Credentry SSO: disabled (set repo variable CREDENTRY_ENABLED=true once provisioned)"
+          fi
           helm upgrade --install numbatwallet deploy/helm/numbatwallet \
             --namespace ${{ env.NAMESPACE }} \
             --set image.tag=${IMAGE_TAG} \
             --set api.searchTokenPepper="${SEARCH_TOKEN_PEPPER}" \
+            "${CREDENTRY_ARGS[@]}" \
             --wait --timeout 10m
 
       # On timeout/failure, print the crashing pods' logs so
@@ -197,3 +221,38 @@ jobs:
           kubectl run nw-smoke --rm -i --restart=Never --namespace ${{ env.NAMESPACE }} \
             --image=curlimages/curl:8.10.1 -- \
             curl -fsS -o /dev/null -w "%{http_code}" http://numbatwallet-api/health
+
+      # Post-deploy federation contract check: mint a real Credentry client-credentials
+      # token and call a tenant-scoped endpoint through it. SKIPS cleanly until Credentry
+      # provisions the nonprod numbatwallet-m2m client (secret CREDENTRY_M2M_CLIENT_SECRET
+      # + variable CREDENTRY_AUTHORITY). Proves the live federation end-to-end once enabled.
+      - name: Credentry M2M contract smoke
+        env:
+          CREDENTRY_AUTHORITY: ${{ vars.CREDENTRY_AUTHORITY }}
+          M2M_CLIENT_ID: ${{ vars.CREDENTRY_M2M_CLIENT_ID }}
+          M2M_CLIENT_SECRET: ${{ secrets.CREDENTRY_M2M_CLIENT_SECRET }}
+          API_BASE: https://tst.numbatwallet.credentry.com.au
+        run: |
+          if [ -z "${M2M_CLIENT_SECRET}" ] || [ -z "${CREDENTRY_AUTHORITY}" ]; then
+            echo "Credentry M2M smoke: SKIPPED (CREDENTRY_M2M_CLIENT_SECRET / CREDENTRY_AUTHORITY not set yet)"
+            exit 0
+          fi
+          CLIENT_ID="${M2M_CLIENT_ID:-numbatwallet-m2m}"
+          echo ">>> Requesting client_credentials token from ${CREDENTRY_AUTHORITY}/connect/token"
+          TOKEN=$(curl -fsS -X POST "${CREDENTRY_AUTHORITY}/connect/token" \
+            -d grant_type=client_credentials \
+            -d "client_id=${CLIENT_ID}" \
+            -d "client_secret=${M2M_CLIENT_SECRET}" \
+            -d scope=numbatwallet.api | jq -r .access_token)
+          if [ -z "${TOKEN}" ] || [ "${TOKEN}" = "null" ]; then
+            echo "::error::Failed to obtain an M2M token from Credentry"; exit 1
+          fi
+          echo ">>> Calling a tenant-scoped endpoint with the Credentry token"
+          CODE=$(curl -sS -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            "${API_BASE}/api/v1/persons?page=1&pageSize=1")
+          echo "GET /api/v1/persons -> HTTP ${CODE}"
+          if [ "${CODE}" != "200" ]; then
+            echo "::error::Credentry M2M contract smoke failed (expected 200, got ${CODE})"; exit 1
+          fi
+          echo "Credentry M2M contract smoke: PASSED"

--- a/deploy/helm/numbatwallet/templates/deployment-admin.yaml
+++ b/deploy/helm/numbatwallet/templates/deployment-admin.yaml
@@ -41,7 +41,14 @@ spec:
                 - ALL
           env:
             - name: ASPNETCORE_ENVIRONMENT
+              {{- if .Values.admin.credentry.enabled }}
+              # Credentry SSO requires a non-Development environment so "Sign in with Credentry"
+              # is the SOLE interactive login (Web.Admin auth mode 2). Forced here so enabling
+              # Credentry and the environment can never desync into the Azure-AD branch.
+              value: "Staging"
+              {{- else }}
               value: {{ .Values.admin.environment | quote }}
+              {{- end }}
             - name: ASPNETCORE_URLS
               value: "http://+:8080"
             - name: ASPNETCORE_FORWARDEDHEADERS_ENABLED
@@ -60,6 +67,32 @@ spec:
                   key: admin-api-key
             - name: AdminApi__TenantId
               value: {{ .Values.admin.tenantId | quote }}
+
+            {{- if .Values.admin.credentry.enabled }}
+            # "Sign in with Credentry" (auth-code + PKCE, client numbatwallet-admin). The client
+            # secret comes from the K8s secret (sourced from Key Vault); never templated inline.
+            - name: Credentry__Enabled
+              value: "true"
+            - name: Credentry__Authority
+              value: {{ .Values.admin.credentry.authority | quote }}
+            - name: Credentry__RequireHttpsMetadata
+              value: {{ .Values.admin.credentry.requireHttpsMetadata | quote }}
+            - name: Credentry__ClientId
+              value: {{ .Values.admin.credentry.clientId | quote }}
+            - name: Credentry__ClientSecret
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secretName }}
+                  key: credentry-admin-client-secret
+            {{- range $i, $scope := .Values.admin.credentry.scopes }}
+            - name: Credentry__Scopes__{{ $i }}
+              value: {{ $scope | quote }}
+            {{- end }}
+            {{- range $credentryTenant, $numbatTenant := .Values.admin.credentry.tenantMap }}
+            - name: Credentry__TenantMap__{{ $credentryTenant }}
+              value: {{ $numbatTenant | quote }}
+            {{- end }}
+            {{- end }}
 
           resources:
             {{- toYaml .Values.admin.resources | nindent 12 }}

--- a/deploy/helm/numbatwallet/templates/deployment-api.yaml
+++ b/deploy/helm/numbatwallet/templates/deployment-api.yaml
@@ -108,6 +108,25 @@ spec:
                   name: {{ .Values.secretName }}
                   key: admin-api-key
 
+            {{- if .Values.api.credentry.enabled }}
+            # Credentry SSO federation — validates Credentry-issued RS256 access tokens.
+            # CredentryOptionsValidator fail-fast-checks these at startup.
+            - name: Credentry__Enabled
+              value: "true"
+            - name: Credentry__Authority
+              value: {{ .Values.api.credentry.authority | quote }}
+            - name: Credentry__Audience
+              value: {{ .Values.api.credentry.audience | quote }}
+            - name: Credentry__RequiredProduct
+              value: {{ .Values.api.credentry.requiredProduct | quote }}
+            - name: Credentry__RequireHttpsMetadata
+              value: {{ .Values.api.credentry.requireHttpsMetadata | quote }}
+            {{- range $credentryTenant, $numbatTenant := .Values.api.credentry.tenantMap }}
+            - name: Credentry__TenantMap__{{ $credentryTenant }}
+              value: {{ $numbatTenant | quote }}
+            {{- end }}
+            {{- end }}
+
             {{- with .Values.api.extraEnv }}
             # Ad-hoc environment (set at deploy time, e.g. --set-json api.extraEnv=...)
             {{- toYaml . | nindent 12 }}

--- a/deploy/helm/numbatwallet/values.yaml
+++ b/deploy/helm/numbatwallet/values.yaml
@@ -63,6 +63,22 @@ api:
   # for deploy-time-only configuration (e.g. an ephemeral extra ApiKey:Keys entry
   # for smoke/perf tooling). Keep empty in committed values.
   extraEnv: []
+  # Credentry SSO federation — the API VALIDATES Credentry-issued RS256 access tokens
+  # (additional bearer scheme; never replaces API-key / citizen auth). Committed DISABLED
+  # and without secrets; turned on at deploy time once Credentry provisions the nonprod
+  # clients (set CREDENTRY_ENABLED + the tenant-map repo variables, or --set directly).
+  # The API needs no client secret — it only validates tokens. Contract:
+  # credentry/docs/integration/06-NUMBATWALLET-FEDERATION-CONTRACT.md.
+  credentry:
+    enabled: false
+    authority: "https://tst.portal.credentry.com.au"
+    audience: "numbatwallet-api"
+    requiredProduct: "NUMBATWALLET"
+    requireHttpsMetadata: true
+    # Credentry tenant GUID -> NumbatWallet tenant GUID. Populated at enable time with the
+    # real nonprod Credentry tenant GUID, mapping to the AKS Testing seed tenant
+    # (00000000-0000-0000-0000-000000000000). Unmapped tenants fail closed.
+    tenantMap: {}
 
 admin:
   replicas: 1
@@ -81,6 +97,27 @@ admin:
   # Ambient tenant used at seed time when no HTTP context exists (Guid.Empty
   # fail-closed value) — the Admin portal must address the same tenant.
   tenantId: "00000000-0000-0000-0000-000000000000"
+  # Credentry SSO ("Sign in with Credentry", auth-code + PKCE, client numbatwallet-admin).
+  # When enabled the deployment template forces a non-Development ASPNETCORE_ENVIRONMENT so
+  # Credentry becomes the SOLE interactive login (Web.Admin auth mode 2) — enabling the flag
+  # and the environment can never desync. The client secret is delivered via the K8s secret
+  # key 'credentry-admin-client-secret' (bootstrap-namespace.sh ← Key Vault), never here.
+  # Committed DISABLED; turn on together with api.credentry at enable time.
+  credentry:
+    enabled: false
+    authority: "https://tst.portal.credentry.com.au"
+    requireHttpsMetadata: true
+    clientId: "numbatwallet-admin"
+    scopes:
+      - openid
+      - profile
+      - email
+      - offline_access
+      - credentry.api
+      - credentry.roles
+      - numbatwallet.api
+    # Credentry tenant GUID -> NumbatWallet tenant GUID (same mapping as api.credentry).
+    tenantMap: {}
 
 migrations:
   # Helm pre-install/pre-upgrade hook Job (EF Core migrations bundle)

--- a/deploy/scripts/bootstrap-namespace.sh
+++ b/deploy/scripts/bootstrap-namespace.sh
@@ -10,6 +10,10 @@
 #       jwt-secret-key                   -> jwt-secret-key
 #       field-encryption-key             -> field-encryption-key
 #       admin-api-key                    -> admin-api-key
+#       credentry-admin-client-secret    -> credentry-admin-client-secret  (optional;
+#         the "Sign in with Credentry" OIDC client secret. Empty until Credentry provisions
+#         the nonprod numbatwallet-admin client — the admin pod only reads it when
+#         admin.credentry.enabled=true, so an empty placeholder is harmless before then.)
 #
 # Prerequisites:
 #   - az login (with access to subscription "Credenxia AU LAB" for the product KV)
@@ -47,6 +51,10 @@ CONNECTION_STRING="$(get_kv 'ConnectionStrings--numbatwallet')"
 JWT_SECRET_KEY="$(get_kv 'jwt-secret-key')"
 FIELD_ENCRYPTION_KEY="$(get_kv 'field-encryption-key')"
 ADMIN_API_KEY="$(get_kv 'admin-api-key')"
+# Optional — present only once Credentry provisions the nonprod numbatwallet-admin client.
+# Falls back to empty so bootstrap stays green before then (the key still exists, so the admin
+# pod's secretKeyRef resolves; it's only consumed when admin.credentry.enabled=true).
+CREDENTRY_ADMIN_CLIENT_SECRET="$(get_kv 'credentry-admin-client-secret' 2>/dev/null || echo '')"
 
 echo ">>> Applying K8s secret ${SECRET_NAME} in ${NAMESPACE}"
 kubectl create secret generic "${SECRET_NAME}" \
@@ -55,6 +63,7 @@ kubectl create secret generic "${SECRET_NAME}" \
   --from-literal=jwt-secret-key="${JWT_SECRET_KEY}" \
   --from-literal=field-encryption-key="${FIELD_ENCRYPTION_KEY}" \
   --from-literal=admin-api-key="${ADMIN_API_KEY}" \
+  --from-literal=credentry-admin-client-secret="${CREDENTRY_ADMIN_CLIENT_SECRET}" \
   --dry-run=client -o yaml | kubectl apply -f -
 
 echo ">>> Done. Namespace contents:"

--- a/src/NumbatWallet.Web.Admin/Authentication/AdminAuthMode.cs
+++ b/src/NumbatWallet.Web.Admin/Authentication/AdminAuthMode.cs
@@ -1,0 +1,27 @@
+namespace NumbatWallet.Web.Admin.Authentication;
+
+/// <summary>The admin portal's interactive-login mode (exactly one is active at a time).</summary>
+public enum AdminAuthMode
+{
+    /// <summary>Dev cookie login (/login) for seeded local accounts; Credentry optional.</summary>
+    Development,
+
+    /// <summary>"Sign in with Credentry" is the sole interactive login (deployed test/nonprod).</summary>
+    CredentrySso,
+
+    /// <summary>Azure AD (Entra) sign-in (future production).</summary>
+    AzureAd
+}
+
+/// <summary>Pure, testable selection of the admin authentication mode (see <see cref="AdminAuthMode"/>).</summary>
+public static class AdminAuthentication
+{
+    /// <summary>
+    /// Development always wins (local accounts). Otherwise Credentry SSO is preferred when
+    /// enabled, falling back to Azure AD. This is the single source of truth the host switches on.
+    /// </summary>
+    public static AdminAuthMode ResolveMode(bool isDevelopment, bool credentryEnabled) =>
+        isDevelopment ? AdminAuthMode.Development
+        : credentryEnabled ? AdminAuthMode.CredentrySso
+        : AdminAuthMode.AzureAd;
+}

--- a/src/NumbatWallet.Web.Admin/Program.cs
+++ b/src/NumbatWallet.Web.Admin/Program.cs
@@ -41,10 +41,23 @@ try
     // Admin portal communicates through API only (Clean Architecture)
     // No Application or Infrastructure layer dependencies
 
-    // Add authentication
-    if (builder.Environment.IsDevelopment())
+    // Authentication has three explicit, config-selected modes (never two interactive logins
+    // active at once):
+    //   1. Development          → dev cookie login (/login) for the seeded local accounts.
+    //   2. Credentry SSO        → cookie session whose ONLY interactive login is "Sign in with
+    //      (non-dev, enabled)     Credentry"; the default challenge redirects to the IdP. No
+    //                             Azure AD, no dev login. This is the deployed test-env mode.
+    //   3. Azure AD (Entra)     → non-dev with Credentry disabled (future production).
+    // Contract: credentry/docs/integration/06-NUMBATWALLET-FEDERATION-CONTRACT.md.
+    var credentryEnabled = builder.Configuration.GetValue<bool>("Credentry:Enabled");
+    var authMode = NumbatWallet.Web.Admin.Authentication.AdminAuthentication.ResolveMode(
+        builder.Environment.IsDevelopment(), credentryEnabled);
+    const string credentryCookieScheme =
+        Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationDefaults.AuthenticationScheme; // "Cookies"
+
+    if (authMode == NumbatWallet.Web.Admin.Authentication.AdminAuthMode.Development)
     {
-        // Development: use cookie auth with local login endpoint
+        // Mode 1 — Development: cookie auth with local login endpoint.
         builder.Services.AddAuthentication("NumbatWalletAuth")
             .AddCookie("NumbatWalletAuth", options =>
             {
@@ -53,9 +66,31 @@ try
 
         builder.Services.AddControllersWithViews();
     }
+    else if (authMode == NumbatWallet.Web.Admin.Authentication.AdminAuthMode.CredentrySso)
+    {
+        // Mode 2 — Credentry SSO only: the cookie carries the session; an unauthenticated
+        // request challenges the "Credentry" OIDC handler (registered below) and is redirected
+        // to the IdP. Secure cookies behind Front Door rely on forwarded headers
+        // (ASPNETCORE_FORWARDEDHEADERS_ENABLED=true) so the app knows the request is HTTPS.
+        builder.Services.AddAuthentication(options =>
+            {
+                options.DefaultScheme = credentryCookieScheme;
+                options.DefaultSignInScheme = credentryCookieScheme;
+                options.DefaultChallengeScheme = "Credentry";
+            })
+            .AddCookie(credentryCookieScheme, options =>
+            {
+                options.LoginPath = "/login";
+                options.AccessDeniedPath = "/access-denied";
+                options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+                options.Cookie.SameSite = SameSiteMode.Lax; // login returns via top-level GET redirect
+            });
+
+        builder.Services.AddControllersWithViews();
+    }
     else
     {
-        // Production: use Azure AD authentication
+        // Mode 3 — Azure AD (Entra) authentication.
         builder.Services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
             .AddMicrosoftIdentityWebApp(builder.Configuration.GetSection("AzureAd"));
 
@@ -63,12 +98,10 @@ try
             .AddMicrosoftIdentityUI();
     }
 
-    // Credentry SSO federation (config-gated): adds a "Sign in with Credentry" OIDC option
-    // (authorization code + PKCE against the Credentry IdP, client numbatwallet-admin) that
-    // signs in to the SAME cookie session the existing logins use — the rest of the app is
-    // unaffected. The existing dev cookie login remains the default path.
-    // Contract: credentry/docs/integration/06-NUMBATWALLET-FEDERATION-CONTRACT.md.
-    var credentryEnabled = builder.Configuration.GetValue<bool>("Credentry:Enabled");
+    // "Sign in with Credentry" OIDC handler (authorization code + PKCE against the Credentry
+    // IdP, client numbatwallet-admin). It signs into the SAME cookie session the mode above
+    // established. In Development it is an additional button on the dev login; in Mode 2 it is
+    // the default challenge (the sole interactive login).
     if (credentryEnabled)
     {
         var credentryCfg = builder.Configuration.GetSection("Credentry");

--- a/src/NumbatWallet.Web.Api/Authentication/CredentryAuthenticationExtensions.cs
+++ b/src/NumbatWallet.Web.Api/Authentication/CredentryAuthenticationExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using NumbatWallet.Application.Interfaces;
 using System.IdentityModel.Tokens.Jwt;
@@ -273,21 +274,24 @@ public static class CredentryAuthenticationExtensions
 
         builder.Services
             .AddOptions<JwtBearerOptions>(CredentryAuthenticationDefaults.AuthenticationScheme)
-            .Configure<IConfiguration>((options, config) =>
+            .Configure<IOptionsMonitor<CredentryOptions>>((options, credentryMonitor) =>
             {
-                var section = config.GetSection(CredentryAuthenticationDefaults.ConfigurationSection);
-                var authority = section["Authority"];
+                // Resolved on first use of the scheme (not captured at startup), so late-applied
+                // configuration sources still win — and CredentryOptionsValidator has already
+                // fail-fast-validated this at host start (ValidateOnStart).
+                var credentry = credentryMonitor.CurrentValue;
+                var authority = credentry.Authority;
                 if (string.IsNullOrWhiteSpace(authority))
                 {
                     throw new InvalidOperationException(
                         "Credentry federation is enabled (Credentry:Enabled=true) but Credentry:Authority is not configured.");
                 }
 
-                var audience = section["Audience"] ?? "numbatwallet-api";
+                var audience = credentry.Audience;
 
                 options.Authority = authority;
                 // Dev runs the Credentry IdP on http://localhost:5144; production authorities are HTTPS.
-                options.RequireHttpsMetadata = section.GetValue("RequireHttpsMetadata", true);
+                options.RequireHttpsMetadata = credentry.RequireHttpsMetadata;
                 // Keep the raw OIDC claim names (sub, tid, role, …) — the mapping below is explicit.
                 options.MapInboundClaims = false;
                 options.TokenValidationParameters = new TokenValidationParameters
@@ -342,10 +346,11 @@ public static class CredentryAuthenticationExtensions
             {
                 options.ForwardDefaultSelector = context =>
                 {
-                    // Resolved per request (cheap dictionary lookup) rather than captured at
-                    // startup, so late-applied configuration sources (tests, reload) win.
-                    var authority = context.RequestServices.GetRequiredService<IConfiguration>()
-                        [$"{CredentryAuthenticationDefaults.ConfigurationSection}:Authority"];
+                    // Resolved per request (cheap) rather than captured at startup, so
+                    // late-applied configuration sources (tests, reload) win.
+                    var authority = context.RequestServices
+                        .GetRequiredService<IOptionsMonitor<CredentryOptions>>()
+                        .CurrentValue.Authority;
                     var authorizationHeader = context.Request.Headers.Authorization.FirstOrDefault();
                     return CredentryTokenInspector.IsCredentryToken(authorizationHeader, authority)
                         ? CredentryAuthenticationDefaults.AuthenticationScheme
@@ -358,10 +363,10 @@ public static class CredentryAuthenticationExtensions
 
     private static async Task OnCredentryTokenValidatedAsync(TokenValidatedContext context)
     {
-        var credentrySection = context.HttpContext.RequestServices
-            .GetRequiredService<IConfiguration>()
-            .GetSection(CredentryAuthenticationDefaults.ConfigurationSection);
-        var requiredProduct = credentrySection["RequiredProduct"] ?? CredentryClaimsMapper.RequiredProduct;
+        var credentry = context.HttpContext.RequestServices
+            .GetRequiredService<IOptionsMonitor<CredentryOptions>>()
+            .CurrentValue;
+        var requiredProduct = credentry.RequiredProduct;
         var logger = context.HttpContext.RequestServices
             .GetRequiredService<ILoggerFactory>()
             .CreateLogger("CredentryJwt");
@@ -389,7 +394,7 @@ public static class CredentryAuthenticationExtensions
         var tenantMapped = CredentryClaimsMapper.TryMapTenant(
             identity,
             credentryTenantId,
-            tid => credentrySection.GetSection("TenantMap")[tid]);
+            tid => credentry.TenantMap.GetValueOrDefault(tid));
         if (!tenantMapped)
         {
             logger.LogWarning(

--- a/src/NumbatWallet.Web.Api/Authentication/CredentryOptions.cs
+++ b/src/NumbatWallet.Web.Api/Authentication/CredentryOptions.cs
@@ -1,0 +1,155 @@
+using Microsoft.Extensions.Options;
+
+namespace NumbatWallet.Web.Api.Authentication;
+
+/// <summary>
+/// Strongly-typed binding for the "Credentry" configuration section (see
+/// <see cref="CredentryAuthenticationDefaults.ConfigurationSection"/>). Replaces the ad-hoc
+/// <c>IConfiguration</c> string lookups so misconfiguration fails fast at startup (via the
+/// paired <see cref="CredentryOptionsValidator"/> + <c>ValidateOnStart()</c>) rather than on the
+/// first incoming token. Bound through the options pattern, so late-applied configuration
+/// sources (tests, reload) still win — read it via <c>IOptionsMonitor&lt;CredentryOptions&gt;.CurrentValue</c>.
+/// </summary>
+public sealed class CredentryOptions
+{
+    /// <summary>Configuration section name ("Credentry").</summary>
+    public const string SectionName = CredentryAuthenticationDefaults.ConfigurationSection;
+
+    /// <summary>Master switch. When false the federation wiring is not registered at all.</summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>OIDC authority/issuer (the Credentry IdP). Required when <see cref="Enabled"/>.</summary>
+    public string? Authority { get; set; }
+
+    /// <summary>Expected token audience. Defaults to the contract value "numbatwallet-api".</summary>
+    public string Audience { get; set; } = "numbatwallet-api";
+
+    /// <summary>Required <c>product</c> claim. Defaults to "NUMBATWALLET".</summary>
+    public string RequiredProduct { get; set; } = "NUMBATWALLET";
+
+    /// <summary>
+    /// Whether OIDC metadata retrieval requires HTTPS. Defaults true; set false only for a
+    /// loopback dev IdP (http://localhost:5144).
+    /// </summary>
+    public bool RequireHttpsMetadata { get; set; } = true;
+
+    /// <summary>
+    /// Credentry tenant GUID → NumbatWallet tenant GUID translation table. The two systems own
+    /// different tenant GUIDs (deliberate), so every accepted tenant must have an entry here.
+    /// An unmapped Credentry tenant FAILS CLOSED (no tenant_id claim → EF filters match nothing).
+    /// Case-insensitive keys so token casing/format differences don't break the lookup.
+    /// </summary>
+    public Dictionary<string, string> TenantMap { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+}
+
+/// <summary>
+/// Fail-fast validation for <see cref="CredentryOptions"/>, run at host start
+/// (<c>ValidateOnStart()</c>). Environment-agnostic by design: the only HTTP exception is a
+/// loopback authority (the dev/stub IdP), so the rules protect every non-local deployment
+/// without coupling to <c>IHostEnvironment</c> (which keeps the existing federation tests —
+/// which run a stub IdP on 127.0.0.1 — green).
+/// </summary>
+public sealed class CredentryOptionsValidator : IValidateOptions<CredentryOptions>
+{
+    public ValidateOptionsResult Validate(string? name, CredentryOptions options)
+    {
+        // Disabled federation is always valid — nothing is wired.
+        if (!options.Enabled)
+        {
+            return ValidateOptionsResult.Success;
+        }
+
+        var failures = new List<string>();
+
+        // Authority: present + absolute URI.
+        if (string.IsNullOrWhiteSpace(options.Authority))
+        {
+            failures.Add("Credentry:Authority is required when Credentry:Enabled is true.");
+        }
+        else if (!Uri.TryCreate(options.Authority, UriKind.Absolute, out var authorityUri))
+        {
+            failures.Add($"Credentry:Authority ('{options.Authority}') must be an absolute URI.");
+        }
+        else if (!string.Equals(authorityUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
+                 !string.Equals(authorityUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            // Reject file://, ftp://, etc. (a bare "/path" parses as file:// on Unix).
+            failures.Add($"Credentry:Authority ('{options.Authority}') must be an http or https URL.");
+        }
+        else if (!authorityUri.IsLoopback &&
+                 !string.Equals(authorityUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            // Non-loopback authorities must be HTTPS — federation tokens are bearer credentials.
+            failures.Add($"Credentry:Authority ('{options.Authority}') must use HTTPS unless it is a loopback address.");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.Audience))
+        {
+            failures.Add("Credentry:Audience must not be empty when Credentry:Enabled is true.");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.RequiredProduct))
+        {
+            failures.Add("Credentry:RequiredProduct must not be empty when Credentry:Enabled is true.");
+        }
+
+        // TenantMap: at least one real mapping, and every real key/value a parseable GUID. An
+        // enabled federation with no tenant map can never resolve a tenant, so it's a misconfig.
+        // Keys beginning with '_' are treated as inline documentation (a common JSON-config
+        // comment convention) and ignored — they never match a GUID tenant lookup at runtime.
+        var realEntries = options.TenantMap
+            .Where(kvp => !kvp.Key.StartsWith('_'))
+            .ToList();
+
+        if (realEntries.Count == 0)
+        {
+            failures.Add(
+                "Credentry:TenantMap must contain at least one Credentry-tenant → NumbatWallet-tenant " +
+                "mapping when Credentry:Enabled is true (otherwise every token fails closed with no tenant).");
+        }
+        else
+        {
+            foreach (var (key, value) in realEntries)
+            {
+                if (!Guid.TryParse(key, out _))
+                {
+                    failures.Add($"Credentry:TenantMap key '{key}' is not a valid GUID.");
+                }
+
+                if (!Guid.TryParse(value, out _))
+                {
+                    failures.Add($"Credentry:TenantMap['{key}'] value '{value}' is not a valid GUID.");
+                }
+            }
+        }
+
+        return failures.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+    }
+}
+
+/// <summary>DI helpers for binding + validating <see cref="CredentryOptions"/>.</summary>
+public static class CredentryOptionsServiceCollectionExtensions
+{
+    /// <summary>
+    /// Binds the "Credentry" section to <see cref="CredentryOptions"/> and registers the
+    /// fail-fast validator (runs at host start). Safe to call unconditionally — when the
+    /// section has <c>Enabled=false</c> the validator passes without further checks.
+    /// </summary>
+    public static IServiceCollection AddCredentryOptions(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services.AddSingleton<IValidateOptions<CredentryOptions>, CredentryOptionsValidator>();
+        services
+            .AddOptions<CredentryOptions>()
+            .Bind(configuration.GetSection(CredentryOptions.SectionName))
+            .ValidateOnStart();
+
+        return services;
+    }
+}

--- a/src/NumbatWallet.Web.Api/Program.cs
+++ b/src/NumbatWallet.Web.Api/Program.cs
@@ -170,6 +170,8 @@ try
     // pre-existing default scheme — self-issued JWTs, the API-key middleware and the
     // (dead-code) Azure AD/ServiceWA schemes are untouched (integrate-first, delete-later).
     var credentryEnabled = builder.Configuration.GetValue<bool>("Credentry:Enabled");
+    // Bind + fail-fast-validate the Credentry options at host start (no-op when disabled).
+    builder.Services.AddCredentryOptions(builder.Configuration);
     if (builder.Environment.IsDevelopment() || builder.Environment.IsEnvironment("Testing"))
     {
         // Development/Testing: Use test handler for easier testing

--- a/src/Tests/NumbatWallet.Web.Admin.Tests/Authentication/AdminAuthModeTests.cs
+++ b/src/Tests/NumbatWallet.Web.Admin.Tests/Authentication/AdminAuthModeTests.cs
@@ -1,0 +1,41 @@
+using FluentAssertions;
+using NumbatWallet.Web.Admin.Authentication;
+
+namespace NumbatWallet.Web.Admin.Tests.Authentication;
+
+/// <summary>
+/// The admin portal must run exactly one interactive-login mode. Development always uses the
+/// local cookie login; outside Development, Credentry SSO is the sole login when enabled,
+/// otherwise Azure AD. This guards the deployed test env from silently falling back to Azure AD
+/// (which it has no app registration for) when Credentry is on.
+/// </summary>
+public class AdminAuthModeTests
+{
+    [Fact]
+    public void Development_AlwaysUsesDevCookieLogin_EvenWhenCredentryEnabled()
+    {
+        AdminAuthentication.ResolveMode(isDevelopment: true, credentryEnabled: true)
+            .Should().Be(AdminAuthMode.Development);
+    }
+
+    [Fact]
+    public void Development_WithCredentryDisabled_UsesDevCookieLogin()
+    {
+        AdminAuthentication.ResolveMode(isDevelopment: true, credentryEnabled: false)
+            .Should().Be(AdminAuthMode.Development);
+    }
+
+    [Fact]
+    public void NonDevelopment_WithCredentryEnabled_UsesCredentrySso()
+    {
+        AdminAuthentication.ResolveMode(isDevelopment: false, credentryEnabled: true)
+            .Should().Be(AdminAuthMode.CredentrySso);
+    }
+
+    [Fact]
+    public void NonDevelopment_WithCredentryDisabled_FallsBackToAzureAd()
+    {
+        AdminAuthentication.ResolveMode(isDevelopment: false, credentryEnabled: false)
+            .Should().Be(AdminAuthMode.AzureAd);
+    }
+}

--- a/src/Tests/NumbatWallet.Web.Admin.Tests/NumbatWallet.Web.Admin.Tests.csproj
+++ b/src/Tests/NumbatWallet.Web.Admin.Tests/NumbatWallet.Web.Admin.Tests.csproj
@@ -26,4 +26,8 @@
     <Using Include="Xunit" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\NumbatWallet.Web.Admin\NumbatWallet.Web.Admin.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Tests/NumbatWallet.Web.Api.Tests/Authentication/CredentryOptionsValidatorTests.cs
+++ b/src/Tests/NumbatWallet.Web.Api.Tests/Authentication/CredentryOptionsValidatorTests.cs
@@ -1,0 +1,149 @@
+using FluentAssertions;
+using NumbatWallet.Web.Api.Authentication;
+using Xunit;
+
+namespace NumbatWallet.Web.Api.Tests.Authentication;
+
+/// <summary>
+/// Fail-fast validation rules for <see cref="CredentryOptions"/> (run at host start via
+/// ValidateOnStart). The rules are environment-agnostic: only loopback authorities may be HTTP.
+/// </summary>
+public class CredentryOptionsValidatorTests
+{
+    private const string ValidCredentryTenant = "34c1955b-485e-4aab-bf5c-08488f3e80b5";
+    private const string ValidNumbatTenant = "00000000-0000-0000-0000-000000000001";
+
+    private static readonly CredentryOptionsValidator Validator = new();
+
+    private static CredentryOptions Enabled(Action<CredentryOptions>? mutate = null)
+    {
+        var options = new CredentryOptions
+        {
+            Enabled = true,
+            Authority = "https://tst.portal.credentry.com.au",
+            TenantMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [ValidCredentryTenant] = ValidNumbatTenant
+            }
+        };
+        mutate?.Invoke(options);
+        return options;
+    }
+
+    [Fact]
+    public void Disabled_IsAlwaysValid_EvenWithGarbageConfig()
+    {
+        var options = new CredentryOptions
+        {
+            Enabled = false,
+            Authority = null,
+            TenantMap = new Dictionary<string, string>()
+        };
+
+        Validator.Validate(null, options).Succeeded.Should().BeTrue(
+            "a disabled federation wires nothing, so its other fields are irrelevant");
+    }
+
+    [Fact]
+    public void Enabled_WithHttpsAuthorityAndValidMap_IsValid()
+    {
+        Validator.Validate(null, Enabled()).Succeeded.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Enabled_WithLoopbackHttpAuthority_IsValid()
+    {
+        // The dev/stub IdP runs over loopback HTTP — must remain valid.
+        var options = Enabled(o => o.Authority = "http://127.0.0.1:5144");
+
+        Validator.Validate(null, options).Succeeded.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Enabled_WithLocalhostHttpAuthority_IsValid()
+    {
+        var options = Enabled(o => o.Authority = "http://localhost:5144");
+
+        Validator.Validate(null, options).Succeeded.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Enabled_WithoutAuthority_Fails()
+    {
+        var result = Validator.Validate(null, Enabled(o => o.Authority = null));
+
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("Authority");
+    }
+
+    [Fact]
+    public void Enabled_WithRelativeAuthority_Fails()
+    {
+        // No scheme → not an absolute URI.
+        var result = Validator.Validate(null, Enabled(o => o.Authority = "credentry.example.com"));
+
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("absolute");
+    }
+
+    [Fact]
+    public void Enabled_WithNonHttpScheme_Fails()
+    {
+        // A bare "/path" parses as an absolute file:// URI on Unix — must still be rejected.
+        var result = Validator.Validate(null, Enabled(o => o.Authority = "/connect"));
+
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("http or https");
+    }
+
+    [Fact]
+    public void Enabled_WithNonLoopbackHttpAuthority_Fails()
+    {
+        var result = Validator.Validate(null, Enabled(o => o.Authority = "http://tst.portal.credentry.com.au"));
+
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("HTTPS");
+    }
+
+    [Fact]
+    public void Enabled_WithEmptyTenantMap_Fails()
+    {
+        var result = Validator.Validate(null, Enabled(o => o.TenantMap = new Dictionary<string, string>()));
+
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("TenantMap");
+    }
+
+    [Fact]
+    public void Enabled_WithNonGuidTenantMapKey_Fails()
+    {
+        var result = Validator.Validate(null, Enabled(o => o.TenantMap = new Dictionary<string, string>
+        {
+            ["not-a-guid"] = ValidNumbatTenant
+        }));
+
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("not a valid GUID");
+    }
+
+    [Fact]
+    public void Enabled_WithNonGuidTenantMapValue_Fails()
+    {
+        var result = Validator.Validate(null, Enabled(o => o.TenantMap = new Dictionary<string, string>
+        {
+            [ValidCredentryTenant] = "not-a-guid"
+        }));
+
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("not a valid GUID");
+    }
+
+    [Fact]
+    public void Enabled_WithEmptyAudience_Fails()
+    {
+        var result = Validator.Validate(null, Enabled(o => o.Audience = ""));
+
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("Audience");
+    }
+}


### PR DESCRIPTION
## What
Production-grade preparation to turn on **Credentry SSO** in the deployed test env. Every change is a **no-op until `Credentry:Enabled` is set**, so it ships safely now; the env goes live with a single config flip once Credentry provisions the nonprod clients.

> The Credentry repo is intentionally **untouched** (their Vizie integration is in flight — avoiding two coding sessions in that repo). Credentry-side provisioning (merge `feature/numbatwallet-federation` + nonprod clients) and the final enable/verify remain a later hand-off.

## Changes
**API (B):** typed `CredentryOptions` + `IValidateOptions` validator with `ValidateOnStart` (fail-fast at host start). Rules are environment-agnostic: enabled ⇒ absolute http(s) authority, non-loopback must be https, `TenantMap` non-empty with valid GUID keys/values (`_`-prefixed keys are inline comments). Scheme/selector/token-validated handler refactored to read `IOptionsMonitor<CredentryOptions>` instead of ad-hoc `IConfiguration`.

**Admin (C):** replaced the binary Development/AzureAd split with three explicit, testable modes (`AdminAuthMode` + pure resolver): Development cookie login, **Credentry-SSO-only** (cookie session + `DefaultChallengeScheme=Credentry`, no Azure AD / dev login), Azure AD. Fixes the prior gap where non-Development signed into an unregistered cookie scheme.

**Deploy (D/E):** `credentry:` Helm values (committed disabled, no secrets); conditional `Credentry__*` env in both deployments; admin `ASPNETCORE_ENVIRONMENT` forced non-Development when enabled so the flag/env can't desync; `bootstrap-namespace.sh` maps optional KV secret `credentry-admin-client-secret`; deploy workflow gains a conditional `--set` gated on repo variable `CREDENTRY_ENABLED` (off until provisioned) + a post-deploy M2M client-credentials contract smoke that **skips cleanly** until the m2m secret exists.

## Tests
866 unit tests, 0 failures (Domain 202, SK 52, App 155, Infra 331, WebApi 122 [+13 new], Admin 4 [new]). Helm chart lints + renders clean both disabled and enabled.

## To enable later (hand-off, after Credentry provisions nonprod)
1. Populate KV `credentry-admin-client-secret`, re-run `bootstrap-namespace.sh`.
2. Set repo vars `CREDENTRY_ENABLED=true`, `CREDENTRY_AUTHORITY`, tenant-map GUIDs; secret `CREDENTRY_M2M_CLIENT_SECRET`.
3. Deploy via `test`; the M2M smoke verifies the live federation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)